### PR TITLE
Updated babeltrace2 ruby bindings.

### DIFF
--- a/packages/ruby-babeltrace2/package.py
+++ b/packages/ruby-babeltrace2/package.py
@@ -10,6 +10,8 @@ class RubyBabeltrace2(RubyPackage):
     homepage = "https://github.com/argonne-lcf/babeltrace2-ruby"
     url      = "https://rubygems.org/downloads/babeltrace2-0.1.1.gem"
 
+    version('0.1.3', sha256='549cbd03c6e4987cb935ee20ca69887f8fd6bd5d2e6d9fca0706b63d966fca5c', expand=False)
+    version('0.1.2', sha256='a09696933a5d36b2833bd6e3bda5b3981d9719ee77c71a5542ccc127e02b27c3', expand=False)
     version('0.1.1', sha256='2a5c35a72ded62240230dd5b31eb7f2e6cdeabc5b29685a0b636c73c17a6c30c', expand=False)
 
     depends_on('ruby@2.3.0:', type=('build', 'run'))


### PR DESCRIPTION
Babeltrace 2 ruby bindings have to be updated as there was a potential segfault in them. The segfault only affected development (thapi tests).