### PR TITLE
Started troubleshooting section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,40 @@ git clone -c feature.manyFiles=true -b releases/latest https://github.com/spack/
 
 You can use spack to install THAPI, then use `spack build-env thapi` to get the correct environment required to build THAPI for source. ( `spack build-env thapi bash` will spwan a new bash will all the ENV variable corretcly set) 
 
+# Troubleshooting
+## Errors with the C Compiler
+
+If spack cannot find or use your C compiler (may see messages like `C compiler cannot create executables` or that your compiler `does not have your C++ compiler configured`), you may need to make sure spack is using gcc version 11.4.0 instead of more recent versions that can conflict with your build process. Run `spack config get compilers` to check your gcc version for spack. You might see only more recent versions of gcc like 12.3.0, or both 11.4.0 and newer versions. Either way, you will want to [manually conifgure your compilers](https://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration) so that ONLY gcc 11.4.0 is present. This edit can be done by running `spack config edit compilers`. You can then remove the section that looks similar to this:
+
+```
+- compiler:
+    spec: gcc@=12.3.0
+    paths:
+      cc: /usr/bin/gcc-12
+      cxx: null
+      f77: null
+      fc: null
+    flags: {}
+    operating_system: ubuntu22.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+```
+and add/keep the section that looks something like this:
+```
+- compiler:
+    spec: gcc@=11.4.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu22.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+```
+allowing you to rebuild THAPI.


### PR DESCRIPTION
Debugged an issue with Thomas regarding building THAPI with spack where spack had gcc 12.3.0 instead of 11.4.0. Added a troubleshooting section for the README to address this issue (and be a place for any future common errors). The error is shown below:

![image](https://github.com/argonne-lcf/THAPI-spack/assets/72468876/b6d5e1e0-4162-482e-9b42-24a1f4c3c4da)
