### PR TITLE
Add mpi variant

### DIFF
--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -45,7 +45,8 @@ class Thapi(AutotoolsPackage):
     # We don't add Python as a runtime dependency of lttng to avoid python propagated as a runtime dependency of thapi
     depends_on('python', type=('build'))
 
-    variant('strict', default=False, description='Enable -Werror during the build')
+    variant('strict', default=False, description='Enable -Werror during the build')    
+    variant('mpi', default=False, description='Enable MPI support for the Sync Daemon')
     def configure_args(self):
         args = [] 
         args.extend(self.enable_or_disable('mpi'))

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -40,12 +40,14 @@ class Thapi(AutotoolsPackage):
 
     depends_on('libiberty+pic')
     depends_on('libffi')
+    depends_on('mpi', when='+mpi')
     # We add a Python dependency at buildtime, because `lttng-gen-tp` needs it.
     # We don't add Python as a runtime dependency of lttng to avoid python propagated as a runtime dependency of thapi
     depends_on('python', type=('build'))
 
     variant('strict', default=False, description='Enable -Werror during the build')
     def configure_args(self):
-        args = []
+        args = [] 
+        args.extend(self.enable_or_disable('mpi'))
         args.extend(self.enable_or_disable('strict'))
         return args


### PR DESCRIPTION
It is useful for Aurora when we want to install with `--disable-mpi` because MPI is broken.