### PR TITLE
Check c/cxx compiler and `lttng ust` version

### DIFF
--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -38,7 +38,7 @@ class Thapi(AutotoolsPackage):
     depends_on('lttng-ust@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')
     depends_on('lttng-tools@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')
 
-    # Check compilers and versions. Version hecks are mainly for magic_enum:
+    # Check compilers and versions. Version checks are mainly for magic_enum:
     # https://github.com/Neargye/magic_enum?tab=readme-ov-file#compiler-compatibility
     conflicts('%gcc@:8', msg='GCC version >= 9 required.')
     conflicts('%llvm@:4', msg='clang >= 5 required.')

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -42,6 +42,7 @@ class Thapi(AutotoolsPackage):
     # https://github.com/Neargye/magic_enum?tab=readme-ov-file#compiler-compatibility
     conflicts('%gcc@:8', msg='GCC version >= 9 required.')
     conflicts('%llvm@:4', msg='clang >= 5 required.')
+    conflicts("%oneapi@:2023", msg="OneAPI >= 2024.0.0 is required.")
     conflicts('%msvc', msg='MSVC is not supported.')
 
     # Restricting to ruby <= 3.1 when spack is less than 0.23

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -33,6 +33,7 @@ class Thapi(AutotoolsPackage):
     depends_on('babeltrace2', type=('build', 'link', 'run'))
     depends_on('protobuf@3.12.4:', type=('build', 'link', 'run'))
     depends_on('lttng-ust', type=('build', 'link', 'run'), when='@0.0.8:')
+    depends_on('lttng-ust@2.12.8:', type=('build', 'link', 'run'), when='@develop')
     depends_on('lttng-tools', type=('build', 'link', 'run'), when='@0.0.8:')
     depends_on('lttng-ust@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')
     depends_on('lttng-tools@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -22,8 +22,8 @@ class Thapi(AutotoolsPackage):
     version('0.0.8', tag='v0.0.8')
     version('0.0.7', tag='v0.0.7')
 
-    depends_on("c", type=("build"))
-    depends_on("cxx", type=("build"))
+    depends_on('c', type=('build'))
+    depends_on('cxx', type=('build'))
     depends_on('automake', type=('build'))
     depends_on('autoconf', type=('build'))
     depends_on('libtool', type=('build'))
@@ -40,9 +40,9 @@ class Thapi(AutotoolsPackage):
 
     # Check compilers and versions. Version hecks are mainly for magic_enum:
     # https://github.com/Neargye/magic_enum?tab=readme-ov-file#compiler-compatibility
-    conflicts("%gcc@:8", msg="GCC version >= 9 required.")
-    conflicts("%llvm@:4", msg="clang >= 5 required.")
-    conflicts("%msvc", msg="MSVC is not supported.")
+    conflicts('%gcc@:8', msg='GCC version >= 9 required.')
+    conflicts('%llvm@:4', msg='clang >= 5 required.')
+    conflicts('%msvc', msg='MSVC is not supported.')
 
     # Restricting to ruby <= 3.1 when spack is less than 0.23
     if Version(spack.spack_version) < Version("0.23"):

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -22,6 +22,8 @@ class Thapi(AutotoolsPackage):
     version('0.0.8', tag='v0.0.8')
     version('0.0.7', tag='v0.0.7')
 
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
     depends_on('automake', type=('build'))
     depends_on('autoconf', type=('build'))
     depends_on('libtool', type=('build'))
@@ -34,6 +36,12 @@ class Thapi(AutotoolsPackage):
     depends_on('lttng-tools', type=('build', 'link', 'run'), when='@0.0.8:')
     depends_on('lttng-ust@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')
     depends_on('lttng-tools@:2.12.999', type=('build', 'link', 'run'), when='@:0.0.7')
+
+    # Check compilers and versions. Version hecks are mainly for magic_enum:
+    # https://github.com/Neargye/magic_enum?tab=readme-ov-file#compiler-compatibility
+    conflicts("%gcc@:8", msg="GCC version >= 9 required.")
+    conflicts("%llvm@:4", msg="clang >= 5 required.")
+    conflicts("%msvc", msg="MSVC is not supported.")
 
     # Restricting to ruby <= 3.1 when spack is less than 0.23
     if Version(spack.spack_version) < Version("0.23"):


### PR DESCRIPTION
I wanted to check `oneAPI` compiler version as well with the following diff:
```diff
diff --git a/packages/thapi/package.py b/packages/thapi/package.py
index 30d1187..39865fb 100644
--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -42,6 +42,7 @@ class Thapi(AutotoolsPackage):
     # https://github.com/Neargye/magic_enum?tab=readme-ov-file#compiler-compatibility
     conflicts("%gcc@:8", msg="GCC version >= 9 required.")
     conflicts("%llvm@:4", msg="clang >= 5 required.")
+    conflicts("%oneapi@:2024", msg="OneAPI >= 2025.0.0 is required.")
     conflicts("%msvc", msg="MSVC is not supported.")

     # Restricting to ruby <= 3.1 when spack is less than 0.23
```

But seems like `spack` couldn't find the `oneAPI` package on Aurora and
installed its own. Will check a bit more what is going on.

I have the following entry in `~/.spack/linux/compilers.yaml`:
```yaml
- compiler:
    spec: oneapi@=2025.0.0
    paths:
      cc: /opt/aurora/24.180.3/updates/oneapi/compiler/eng-20240629/bin/icx
      cxx: /opt/aurora/24.180.3/updates/oneapi/compiler/eng-20240629/bin/icpx
      f77: null
      fc: null
    flags: {}
    operating_system: sles15
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
```