### PR TITLE
Fixes for babeltrace2 and lttng-ust in Polaris

### DIFF
--- a/packages/babeltrace2/package.py
+++ b/packages/babeltrace2/package.py
@@ -67,6 +67,11 @@ class Babeltrace2(AutotoolsPackage):
     patch('3079913.patch', when='@:2.0.999')
     patch('0001-ctf-grow-stored_values-array-when-necessary.patch', when='@:2.0.999')
 
+    def setup_build_environment(self, env: EnvironmentModifications):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["glib"].prefix.lib)
+        env.prepend_path("LDFLAGS", "-L" + self.spec["elfutils"].prefix.lib)
+        env.prepend_path("CFLAGS", "-I" + self.spec["elfutils"].prefix.include)
+
     def configure_args(self):
         args = []
         args.extend(self.enable_or_disable('python-bindings'))

--- a/packages/lttng-ust/package.py
+++ b/packages/lttng-ust/package.py
@@ -45,6 +45,10 @@ class LttngUst(AutotoolsPackage):
     depends_on('numactl')
     depends_on('pkg-config')
 
+    def setup_build_environment(self, env: EnvironmentModifications):
+        env.prepend_path("LDFLAGS", "-L" + self.spec["numactl"].prefix.lib)
+        env.prepend_path("CFLAGS", "-I" + self.spec["numactl"].prefix.include)
+
     def configure_args(self):
         args = []
         args.extend(self.enable_or_disable("api-doc"))


### PR DESCRIPTION
I need the following changes in Polaris in order to install `thapi@develop`. The configure step
of `babeltrace2` and `lttng-ust` fails otherwise. Technically, these shouldn't be necessary as
spack correctly sets `PKG_CONFIG_PATH`  for all the dependencies (`glib`, `elfutils`, and `numactl`).

I manually inspected the `spack-build-env.txt` files for `babeltrace2` and `lttng-ust` and
found the respective dependent package paths are in `PKG_CONFIG_PATH`.  But for some reason,
`configure` can't find these packages without these changes. I am using the latest spack 
`develop` branch.

Should we do more investigative work before merging these changes?