### PR TITLE
Use `detached=true` in tmate

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -43,6 +43,8 @@ jobs:
         path: external/spack
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
+      with:
+        detached: true
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
     - name: Setup spack environment
       run: |


### PR DESCRIPTION
From the docs:

> By default, this mode will wait at the end of the job for a user to connect and then to terminate the tmate session. If no user has connected within 10 minutes after the post-job step started, it will terminate the tmate session and quit gracefully.