### PR TITLE
Remove workarounds for lttng-ust and lttng-tools

### DIFF
--- a/packages/lttng-tools/package.py
+++ b/packages/lttng-tools/package.py
@@ -73,11 +73,3 @@ class LttngTools(AutotoolsPackage):
         args.extend(self.enable_or_disable("man-pages"))
         args.extend(self.enable_or_disable("tests"))
         return args
-
-    def setup_build_environment(self, env):
-        # Without the following line, configure checks for userspace-rcu headers
-        # fails to find them in some systems.
-        env.prepend_path("CPPFLAGS", "-I" + self.spec["userspace-rcu"].prefix.include)
-        # Without the following line, configure checks for userspace-rcu libraries
-        # fails to find them in some systems.
-        env.prepend_path("LDFLAGS", "-L" + self.spec["userspace-rcu"].prefix.lib)

--- a/packages/lttng-ust/package.py
+++ b/packages/lttng-ust/package.py
@@ -53,11 +53,3 @@ class LttngUst(AutotoolsPackage):
         args.extend(self.enable_or_disable("api-doc"))
         args.extend(self.enable_or_disable("man-pages"))
         return args
-
-    def setup_build_environment(self, env):
-        # Without the following line, configure checks for userspace-rcu headers
-        # fails to find them in some systems.
-        env.prepend_path("CPPFLAGS", "-I" + self.spec["userspace-rcu"].prefix.include)
-        # Without the following line, configure checks for userspace-rcu libraries
-        # fails to find them in some systems.
-        env.prepend_path("LDFLAGS", "-L" + self.spec["userspace-rcu"].prefix.lib)


### PR DESCRIPTION
Seems like these are not necessary once you disable examples/tests.