### PR TITLE
Update ffi

### DIFF
--- a/packages/ruby-ffi/package.py
+++ b/packages/ruby-ffi/package.py
@@ -15,6 +15,8 @@ class RubyFfi(RubyPackage):
     homepage = "https://github.com/ffi/ffi/wiki"
     url = "https://rubygems.org/downloads/ffi-1.15.4.gem"
 
+    version("1.17.2", sha256="297235842e5947cc3036ebe64077584bff583cd7a4e94e9a02fdec399ef46da6", expand=False)
+    version("1.16.3", sha256="6d3242ff10c87271b0675c58d68d3f10148fabc2ad6da52a18123f06078871fb", expand=False)
     version("1.15.4", sha256="56cfca5261ead48688241236adfefb07a000a6d17184d7a4eed48d55b9675d6b", expand=False)
 
     depends_on("ruby@2.3.0:", type=("build", "run"))

--- a/packages/ruby-opencl/package.py
+++ b/packages/ruby-opencl/package.py
@@ -13,6 +13,7 @@ class RubyOpencl(RubyPackage):
     homepage = "https://github.com/Nanosim-LIG/opencl-ruby"
     url = "https://rubygems.org/downloads/opencl_ruby_ffi-1.3.12.gem"
 
+    version("1.3.13", sha256="cee949f04086a068795a41b71fd7fd7714bbde9418cfd86605803bca615201e0", expand=False)
     version("1.3.12", sha256="e177a50112ab3b9379277943b3112110f52ac32eb2f039c2796b5e11762308ce", expand=False)
 
     depends_on("ruby", type=("build", "run"))


### PR DESCRIPTION
Should fix #82 , 
Thilinia if you don't mind testing manualy aka running  this code on a aurora machine (after spack load thapi or just ruby-opencl I suppose)

```
require 'opencl_ruby_ffi'
require 'narray_ffi'

# 960 EU * 8 Threads
if ARGV.length < 1
    global_work_size  = 1
else
    global_work_size = ARGV[0].to_i
end

dev = OpenCL.platforms.map{ |p| p.devices }.flatten.filter{ |d| d.type.include?(OpenCL::DEVICE_TYPE_GPU) }.first
puts "Device: #{dev.name}"
puts "global_work_size #{global_work_size}"

context = OpenCL.create_context([dev])
queue = context.create_command_queue(dev,  :properties =>  OpenCL::CommandQueue::OUT_OF_ORDER_EXEC_MODE_ENABLE)

source = <<EOF
#define MAD_4(x, y)   x = mad(y, x, y);   y = mad(x, y, x);   x = mad(y, x, y);   y = mad(x, y, x);
#define MAD_16(x, y)    MAD_4(x, y);        MAD_4(x, y);        MAD_4(x, y);        MAD_4(x, y);
#define MAD_64(x, y)    MAD_16(x, y);       MAD_16(x, y);       MAD_16(x, y);       MAD_16(x, y);

uint  __attribute__((overloadable)) intel_get_slice_id();
uint  __attribute__((overloadable)) intel_get_subslice_id();
uint  __attribute__((overloadable)) intel_get_eu_id();

__kernel void one_thread(__global unsigned int *ptr, const float _A, const unsigned int selected_wi) {
    if (get_global_id(0) != selected_wi)
        return;

    float x = _A;
    float y = (float)get_global_id(0);

    for(int i=0; i<1E7; i++)
    {
        MAD_16(x, y);
    }
    ptr[0] = x;
    ptr[1] = intel_get_eu_id();
    ptr[2] = intel_get_subslice_id();
    ptr[3] = intel_get_slice_id();
}
EOF
h_up = NArray.int(4)
h_down = NArray.int(4)

d_up =  context.create_buffer(4*OpenCL::UInt1.size, flags: OpenCL::Mem::WRITE_ONLY)
d_down = context.create_buffer(4*OpenCL::UInt1.size, flags: OpenCL::Mem::WRITE_ONLY)

program = context.create_program_with_source(source)
program.build

# This will run only on one EU and one thread
kernel_one_thread_0 = program.create_kernel(:one_thread)
kernel_one_thread_0.set_args(d_up, OpenCL::Float1::new(0), OpenCL::UInt1::new(0))

kernel_one_thread_1 = program.create_kernel(:one_thread)
kernel_one_thread_1.set_args(d_down, OpenCL::Float1::new(0), OpenCL::UInt1::new(global_work_size-1))

puts "Testing concurrent exusion of single work_item kernel"
puts 'One kernel'
start = Time.now
queue.enqueue_ndrange_kernel(kernel_one_thread_0, [global_work_size], local_work_size: [1])
queue.finish
finish = Time.now

one_k = finish-start
puts "#{one_k} s"
# Just zero out the d_up buffer
queue.enqueue_write_buffer(d_up,h_up)
queue.finish

puts 'Two kernels (should be the similar as one)'
start = Time.now
queue.enqueue_ndrange_kernel(kernel_one_thread_0, [global_work_size]) #, local_work_size: [1])
queue.enqueue_ndrange_kernel(kernel_one_thread_1, [global_work_size]) #, local_work_size: [1])
queue.finish
finish = Time.now
two_k = finish-start
puts "#{two_k} s"

queue.enqueue_read_buffer(d_up, h_up)
queue.enqueue_read_buffer(d_down, h_down)
queue.finish
puts
puts "EU/Subslice/Slice used by both kernel. Should be different"
puts "h_up: #{h_up.to_a[1..]}"
puts "h_down: #{h_down.to_a[1..]}"

exit( (two_k / one_k) < 1.20)
```

If it doesn't raise any error (like the one linked in the issue we are good!)