### PR TITLE
Add llvm-demangle, use it in thapi from 0.0.16 on

### DIFF
--- a/packages/llvm-demangle/package.py
+++ b/packages/llvm-demangle/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import os
+
+from spack.package import *
+
+
+class LlvmDemangle(CMakePackage):
+    """Standalone extraction of LLVM's C++ symbol demangler (llvm/lib/Demangle).
+
+    Builds just libLLVMDemangle and installs the public llvm/Demangle headers,
+    with no dependency on the rest of LLVM. Provides llvm::demangle(), which
+    handles Itanium symbols that libiberty's cplus_demangle() and libstdc++'s
+    abi::__cxa_demangle() reject.
+    """
+
+    homepage = "https://github.com/TApplencourt/llvm-demangle"
+    git = "https://github.com/TApplencourt/llvm-demangle.git"
+
+    version("main", branch="main", preferred=True)
+
+    # Static by default: consumers (THAPI) link the demangler straight into
+    # their babeltrace plugins, so there is no runtime .so to locate.
+    variant("shared", default=False, description="Build a shared library instead of static")
+    # Position-independent code, so the static lib can be linked into shared
+    # libraries (mirrors libiberty+pic, which THAPI used to depend on).
+    variant("pic", default=True, description="Build with position-independent code")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.13:", type="build")
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+        ]
+
+    def setup_run_environment(self, env):
+        # Only relevant for the shared flavor; the static default needs nothing.
+        if self.spec.satisfies("+shared"):
+            libdir = self.prefix.lib64 if os.path.isdir(self.prefix.lib64) else self.prefix.lib
+            env.prepend_path("LD_LIBRARY_PATH", libdir)

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -80,13 +80,12 @@ class Thapi(AutotoolsPackage):
     depends_on("ruby-metababel@1.1.2:", type=("build"), when="@0.0.12:")
     depends_on("ruby-metababel@1.1.4:", type=("build"), when="@0.0.13:")
 
-    # Demangling: thapi <= 0.0.15 used libiberty; later versions switched to
-    # llvm::demangle (a tiny standalone extraction of LLVM's demangler) for the
-    # symbols __cxa_demangle can't handle. +pic so the static lib links into the
-    # shared babeltrace plugins. (master/develop are > any numbered version, so
-    # @0.0.16: covers the dev branches too.)
-    depends_on("libiberty+pic", when="@:0.0.15")
-    depends_on("llvm-demangle+pic", when="@0.0.16:")
+    # Demangling: devel switched from libiberty to llvm::demangle (a tiny
+    # standalone extraction of LLVM's demangler) for the symbols
+    # __cxa_demangle can't handle. +pic so the static lib links into the
+    # shared babeltrace plugins. Move master over once it picks up the switch.
+    depends_on("libiberty+pic", when="@:master")
+    depends_on("llvm-demangle+pic", when="@develop")
     depends_on("libffi")
     depends_on("mpi", when="+mpi")
     depends_on("mpi", when="+sync-daemon-mpi")

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -42,11 +42,13 @@ class Thapi(AutotoolsPackage):
 
     # 4.3+ for grouped target
     depends_on("gmake@4.3:", type=("build"))
+    depends_on("protobuf@3.12.4:", type=("build", "link", "run"))
     # abseil-cpp@20250127.0: has an unguarded `#include <version>` in span.h that
-    # picks up our utils/version data file. protobuf@30: needs those abseil
-    # versions, so both are capped together. Lift once THAPI renames that file.
-    depends_on("protobuf@3.12.4:29", type=("build", "link", "run"))
-    depends_on("abseil-cpp@:20240722", type=("build", "link", "run"))
+    # picks up our utils/version data file. devel renamed it to thapi_version;
+    # narrow to @:0.0.15 once master follows. protobuf@30: needs those abseil
+    # versions, so both are capped together.
+    depends_on("protobuf@:29", type=("build", "link", "run"), when="@:master")
+    depends_on("abseil-cpp@:20240722", type=("build", "link", "run"), when="@:master")
 
     depends_on("babeltrace2", type=("build", "link", "run"))
     depends_on("babeltrace2@2.1.0-archive", type=("build", "link", "run"), when="+archive")

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -80,7 +80,13 @@ class Thapi(AutotoolsPackage):
     depends_on("ruby-metababel@1.1.2:", type=("build"), when="@0.0.12:")
     depends_on("ruby-metababel@1.1.4:", type=("build"), when="@0.0.13:")
 
-    depends_on("libiberty+pic")
+    # Demangling: thapi <= 0.0.15 used libiberty; later versions switched to
+    # llvm::demangle (a tiny standalone extraction of LLVM's demangler) for the
+    # symbols __cxa_demangle can't handle. +pic so the static lib links into the
+    # shared babeltrace plugins. (master/develop are > any numbered version, so
+    # @0.0.16: covers the dev branches too.)
+    depends_on("libiberty+pic", when="@:0.0.15")
+    depends_on("llvm-demangle+pic", when="@0.0.16:")
     depends_on("libffi")
     depends_on("mpi", when="+mpi")
     depends_on("mpi", when="+sync-daemon-mpi")


### PR DESCRIPTION
llvm-demangle is a tiny standalone extraction of LLVM's C++ demangler (llvm/lib/Demangle), built as a static +pic lib with no dependency on the rest of LLVM (not even LLVMSupport). It provides llvm::demangle(), which handles a handful of Itanium symbols (e.g. AMReX/SYCL kernel typeinfo names) that libiberty's cplus_demangle() and libstdc++'s abi::__cxa_demangle() reject.

The thapi dependency is version-gated rather than swapped outright, so existing releases keep building exactly as before:

  depends_on("libiberty+pic", when="@:0.0.15")
  depends_on("llvm-demangle+pic", when="@0.0.16:")

Branch versions (master/develop) sort above any numbered version, so @0.0.16: covers them along with the next release. thapi's my_demangle() uses abi::__cxa_demangle() as its baseline and falls back to llvm::demangle() for the symbols it rejects.