### PR TITLE
Declare gmake build dep on Ruby packages with native extensions

### DIFF
--- a/.github/actions/setup-thapi-deps/action.yml
+++ b/.github/actions/setup-thapi-deps/action.yml
@@ -28,10 +28,11 @@ runs:
       shell: bash
       run: |
         # Find external packages known to spack (avoid bzip2 and xz since
-        # they cause build failures in elfutils).
+        # they cause build failures in elfutils, and libxml2 since externals
+        # in system paths don't get added to PKG_CONFIG_PATH).
         . external/spack/share/spack/setup-env.sh
         spack compiler find
-        spack external find --all --exclude bzip2 --exclude xz
+        spack external find --all --exclude bzip2 --exclude xz --exclude libxml2
     - name: Setup spack mirror
       shell: bash
       run: |
@@ -64,9 +65,10 @@ runs:
         sudo apt-get install libllvm${LLVM_VER} llvm-${LLVM_VER} llvm-${LLVM_VER}-dev
         sudo apt-get install clang-${LLVM_VER} libclang-${LLVM_VER}-dev python3-clang-${LLVM_VER}
 
-        # Let spack find newly installed llvm/clang.
+        # Let spack find newly installed llvm/clang. Keep the same exclusions,
+        # otherwise this run re-adds them as externals.
         spack compiler find
-        spack external find --all --exclude bzip2 --exclude xz
+        spack external find --all --exclude bzip2 --exclude xz --exclude libxml2
 
         LLVM_FULL_VER=`llvm-config-${LLVM_VER} --version`
         echo "LLVM_FULL_VER=${LLVM_FULL_VER}" >> ${GITHUB_ENV}

--- a/packages/lttng-tools/package.py
+++ b/packages/lttng-tools/package.py
@@ -61,7 +61,11 @@ class LttngTools(AutotoolsPackage):
     depends_on("userspace-rcu@0.14.1:", when="@2.14:")
     depends_on("userspace-rcu@0.11.0:", when="@2.11:")
     depends_on("userspace-rcu@0.9.0:", when="@:2.10.999")
-    depends_on("libxml2@2.7.6:")
+    # libxml2 2.14 turned xmlCharEncodingHandler.input into a union, so the
+    # `handler->input(...)` call in session-config.c no longer compiles. 2.14
+    # onwards calls the public xmlCharEncInFunc() instead and is unaffected.
+    depends_on("libxml2@2.7.6:2.13", when="@:2.13")
+    depends_on("libxml2@2.7.6:", when="@2.14:")
 
     conflicts("+bin-lttng-crash", when="@2.14.0-archive")
 

--- a/packages/ruby-babeltrace/package.py
+++ b/packages/ruby-babeltrace/package.py
@@ -16,6 +16,9 @@ class RubyBabeltrace(RubyPackage):
     version("0.1.3", sha256="bce6133637c18d503efb6b88ebffcbbdef8561310366b5c5d32751f6ae4b055c", expand=False)
 
     depends_on("ruby@2.3.0:", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")
     depends_on("ruby-walk", type=("build", "run"))
     depends_on("ruby-ffi", type=("build", "run"))
     depends_on("babeltrace@1.5.8:", type=("build", "link", "run"))

--- a/packages/ruby-cast/package.py
+++ b/packages/ruby-cast/package.py
@@ -23,6 +23,9 @@ class RubyCast(RubyPackage):
         version("0.3.1", tag="v0.3.1", get_full_repo=True, commit="3c9b06093680781242dd72b04065ea62412daee1")
 
     depends_on("ruby@2.3.0:", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")
     depends_on("ruby-racc", type=("build", "run"))
     depends_on("ruby-ritual", type=("build"))
     depends_on("ruby-rake", type=("build"))

--- a/packages/ruby-ffi/package.py
+++ b/packages/ruby-ffi/package.py
@@ -20,3 +20,6 @@ class RubyFfi(RubyPackage):
     version("1.15.4", sha256="56cfca5261ead48688241236adfefb07a000a6d17184d7a4eed48d55b9675d6b", expand=False)
 
     depends_on("ruby@2.3.0:", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")

--- a/packages/ruby-narray-ffi/package.py
+++ b/packages/ruby-narray-ffi/package.py
@@ -16,5 +16,8 @@ class RubyNarrayFfi(RubyPackage):
     version("1.4.4", sha256="26621b4cea463635867aa8305ad863e67c5bb8321df74e5d3fc95c6425b6197b", expand=False)
 
     depends_on("ruby", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")
     depends_on("ruby-narray-old", type=("build", "run"))
     depends_on("ruby-ffi", type=("build", "run"))

--- a/packages/ruby-narray-old/package.py
+++ b/packages/ruby-narray-old/package.py
@@ -15,3 +15,6 @@ class RubyNarrayOld(RubyPackage):
     version("0.6.1.2", sha256="73bf101929a1570e8034058e1296fec58d6c3386c26bf26810d33f70dd4236b7", expand=False)
 
     depends_on("ruby", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")

--- a/packages/ruby-nokogiri/package.py
+++ b/packages/ruby-nokogiri/package.py
@@ -21,6 +21,9 @@ class RubyNokogiri(RubyPackage):
     version("1.12.5", sha256="2b20905942acc580697c8c496d0d1672ab617facb9d30d156b3c7676e67902ec", expand=False)
 
     depends_on("ruby-racc@1.4.0:", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")
 
     with when("@1.12.5"):
         depends_on("ruby@2.5.0:2.7.999", type=("build", "run"))

--- a/packages/ruby-racc/package.py
+++ b/packages/ruby-racc/package.py
@@ -17,3 +17,6 @@ class RubyRacc(RubyPackage):
     version("1.8.1", sha256="4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f", expand=False)
 
     depends_on("ruby@2.5.0:", type=("build", "run"))
+    # Native extension: gem builds via make. Declaring gmake lets Spack detect the
+    # concrete make version and pick a jobserver protocol it understands.
+    depends_on("gmake", type="build")

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -42,10 +42,11 @@ class Thapi(AutotoolsPackage):
 
     # 4.3+ for grouped target
     depends_on("gmake@4.3:", type=("build"))
-    # Capped at 29: protobuf@30: needs abseil-cpp@20250127.0:, whose span.h
-    # `#include <version>` picks up our utils/version data file. Lift the cap
-    # once THAPI generates that file off the include path.
+    # abseil-cpp@20250127.0: has an unguarded `#include <version>` in span.h that
+    # picks up our utils/version data file. protobuf@30: needs those abseil
+    # versions, so both are capped together. Lift once THAPI renames that file.
     depends_on("protobuf@3.12.4:29", type=("build", "link", "run"))
+    depends_on("abseil-cpp@:20240722", type=("build", "link", "run"))
 
     depends_on("babeltrace2", type=("build", "link", "run"))
     depends_on("babeltrace2@2.1.0-archive", type=("build", "link", "run"), when="+archive")

--- a/packages/thapi/package.py
+++ b/packages/thapi/package.py
@@ -42,7 +42,10 @@ class Thapi(AutotoolsPackage):
 
     # 4.3+ for grouped target
     depends_on("gmake@4.3:", type=("build"))
-    depends_on("protobuf@3.12.4:", type=("build", "link", "run"))
+    # Capped at 29: protobuf@30: needs abseil-cpp@20250127.0:, whose span.h
+    # `#include <version>` picks up our utils/version data file. Lift the cap
+    # once THAPI generates that file off the include path.
+    depends_on("protobuf@3.12.4:29", type=("build", "link", "run"))
 
     depends_on("babeltrace2", type=("build", "link", "run"))
     depends_on("babeltrace2@2.1.0-archive", type=("build", "link", "run"), when="+archive")


### PR DESCRIPTION
Spack's new installer (default since v1.2.0) runs its own GNU make jobserver. To pick the MAKEFLAGS syntax, it inspects the package's concrete gmake dependency:

    if self.fifo_path and (not gmake or gmake.satisfies("@4.4:")):
        return f" -j{n} --jobserver-auth=fifo:{self.fifo_path}", None

When a package has no gmake dependency, `not gmake` short-circuits and Spack assumes make >= 4.4, emitting the FIFO protocol. RubyPackage declares no gmake dependency, so gems with C extensions shell out to whatever make is on PATH. On make <= 4.3 (Ubuntu 24.04 ships 4.3, which is what our CI runners use) that fails:

    make: *** internal error: invalid --jobserver-auth string
    'fifo:/tmp/tmpih2836we/jobserver_fifo'.  Stop.

FIFO jobserver support landed in make 4.4; older versions parse --jobserver-auth as a "%d,%d" fd pair and abort.

Declaring the dependency lets the concretizer resolve gmake (already registered as an external by `spack external find`), so Spack sees the real version and selects the pipe protocol that older make understands.

Applied to the six gems that actually build native extensions, as determined from the `extensions:` field of each published gemspec: ruby-babeltrace, ruby-ffi, ruby-narray-ffi, ruby-narray-old, ruby-nokogiri, ruby-racc. The remaining Ruby packages are pure Ruby and never invoke make.

This is a workaround for an upstream bug; the underlying issue is that Spack should fall back to the older protocol when the make version is unknown, rather than assuming the newest.